### PR TITLE
run Rex with old Context API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rex-legacy",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Data wrapper",
   "main": "./lib/rex.js",
   "types": "./lib/rex.d.ts",
@@ -49,7 +49,7 @@
     "webpack-hud": "^0.1.2"
   },
   "peerDependencies": {
-    "react": "16.0.0"
+    "react": "16.2.0"
   },
   "dependencies": {
     "immer": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rex-legacy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Data wrapper",
   "main": "./lib/rex.js",
   "types": "./lib/rex.d.ts",

--- a/rex/rex.tsx
+++ b/rex/rex.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import produce from "immer";
 import * as shallowequal from "shallowequal";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 function devPoint(...args) {
   // console.log(...args)


### PR DESCRIPTION
提供 Rex 运行在的 Old Context API 的版本, 以便解决老项目的依赖问题.
